### PR TITLE
Traefik: enable metrics service

### DIFF
--- a/k3s-cluster/networking/traefik-k3s-ssl/traefik-overrides.tf
+++ b/k3s-cluster/networking/traefik-k3s-ssl/traefik-overrides.tf
@@ -70,6 +70,16 @@ resource kubernetes_manifest traefik_override {
           fsGroup = 65532
           fsGroupChangePolicy = "OnRootMismatch"
         }
+
+        # Fucking helm chart enables prometheus metrics by default
+        # but not the fucking service to contact the fucking thing
+        metrics = {
+          prometheus = {
+            service = {
+              enabled = true
+            }
+          }
+        }
       })
     }
   }


### PR DESCRIPTION
As usual, Helm charts are a piece of shit